### PR TITLE
Remove cursor:pointer from non-interactive element

### DIFF
--- a/src/public/css/main.css
+++ b/src/public/css/main.css
@@ -238,7 +238,6 @@ iframe {
 
 .row:hover {
 	background-color: #ececff;
-	cursor: pointer
 }
 
 @media(max-width:768px) {


### PR DESCRIPTION
This can get confusing as the user may be tempted to click on the data rows, only to realize that nothing happens. Usually, the `pointer` cursor is reserved for interactive elements like links, buttons, etc.