### PR TITLE
Reorder list of colors for area highligts

### DIFF
--- a/src/public/js/map-functions.js
+++ b/src/public/js/map-functions.js
@@ -1,6 +1,6 @@
 /* global topojson */
 
-const colors = ['#8dd3c7', '#ffffb3', '#bebada', '#fb8072', '#80b1d3', '#fdb462', '#b3de69', '#fccde5', '#d9d9d9', '#bc80bd', '#ccebc5', '#ffed6f']
+const colors = ['#8dd3c7', '#ffffb3', '#fb8072', '#bebada', '#80b1d3', '#fdb462', '#b3de69', '#fccde5', '#d9d9d9', '#bc80bd', '#ccebc5', '#ffed6f']
 
 export function style (feature) {
   return {

--- a/src/public/js/map-functions.js
+++ b/src/public/js/map-functions.js
@@ -1,6 +1,6 @@
 /* global topojson */
 
-const colors = ['#8dd3c7', '#ffffb3', '#fb8072', '#bebada', '#80b1d3', '#fdb462', '#b3de69', '#fccde5', '#d9d9d9', '#bc80bd', '#ccebc5', '#ffed6f']
+const colors = ['#8dd3c7', '#ffffb3', '#fb8072', '#80b1d3', '#fdb462', '#bebada', '#b3de69', '#fccde5', '#d9d9d9', '#bc80bd', '#ccebc5', '#ffed6f']
 
 export function style (feature) {
   return {

--- a/src/public/js/map-functions.js
+++ b/src/public/js/map-functions.js
@@ -1,5 +1,6 @@
 /* global topojson */
 
+// List of distinctive colors provided by ColorBrewer: https://colorbrewer2.org/#type=qualitative&scheme=Set3&n=12
 const colors = ['#8dd3c7', '#ffffb3', '#fb8072', '#80b1d3', '#fdb462', '#bebada', '#b3de69', '#fccde5', '#d9d9d9', '#bc80bd', '#ccebc5', '#ffed6f']
 
 export function style (feature) {


### PR DESCRIPTION
Follow-up from https://github.com/jfoclpf/geoapi.pt/issues/79#issuecomment-1519092427.

Since the algorithm tries to pick colors from the start of the list, rather than randomly, the order of colors in the list has a marked effect in the resulting distributions of color. This proposal changes the color ordering to produce results that I personally find more pleasant.

What I did was simply move purple (`#bebada`) color down in the list. I like the results better; the color distribution seems to be more even and not as heavy on cool hues — and let's say that the map gets a little less "bêbado" that way :stuck_out_tongue_winking_eye:

| 🔗 | Before | After |
| -- | ------ | ----- |
| [1](https://geoapi.pt/) | ![image](https://user-images.githubusercontent.com/478237/233848995-f4527be7-3222-4296-8792-c4540928ef48.png) | ![image](https://user-images.githubusercontent.com/478237/233849855-3a22b016-29d6-48a4-a722-e10fdf4ba982.png) |
| [2](https://geoapi.pt/distrito/porto/municipios) | ![image](https://user-images.githubusercontent.com/478237/233849177-d0bee737-0b09-4bdd-8ed8-c008c322f1bd.png) | ![image](https://user-images.githubusercontent.com/478237/233849939-52000ebc-bab2-437c-90cc-b327ecf1b46a.png) |
| [3](https://geoapi.pt/municipio/porto/freguesias) | ![image](https://user-images.githubusercontent.com/478237/233849264-23126d89-e690-4452-8127-b83b17c49082.png) | ![image](https://user-images.githubusercontent.com/478237/233849226-b2c8f0f7-b252-4357-847f-0d407e21c315.png) |