### PR TITLE
Fix ocurrences of en/pt false friend «locale»

### DIFF
--- a/src/public/src/css/main.css
+++ b/src/public/src/css/main.css
@@ -173,12 +173,12 @@ textarea:focus {
 	padding-bottom: 15px;
 }
 
-#mylocalbutton {
+#mylocationbutton {
 	text-align: center;
 	padding: 0 10% 15px 10%;
 }
 
-#mylocalbutton a {
+#mylocationbutton a {
 	word-break: break-word;
 	border: #b8b7b7 1px solid;
 	border-radius: 5px;
@@ -189,7 +189,7 @@ textarea:focus {
 	font-size: larger;
 }
 
-#mylocalbutton img {
+#mylocationbutton img {
 	max-height: 110px;
 }
 
@@ -249,7 +249,7 @@ textarea:focus {
 /* ========================== */
 
 @media (min-width: 500px) {
-  #mylocalbutton {
+  #mylocationbutton {
 		display: none;
 	}
 }

--- a/src/public/src/js/index.js
+++ b/src/public/src/js/index.js
@@ -3,7 +3,7 @@ import './index/getDistrictInfo.js'
 import './index/getMunicipalityInfo.js'
 import './index/getParishInfo.js'
 import './index/getPostalCodesInfo.js'
-import './index/getLocaleInfo.js'
+import './index/getLocationInfo.js'
 
 import { mobileCheck, jsonFetchOptions } from './functions.js'
 import * as mapFunctions from './map/map-functions.js'

--- a/src/public/src/js/index/getLocationInfo.js
+++ b/src/public/src/js/index/getLocationInfo.js
@@ -2,7 +2,7 @@
 const inputLatitudeGps = document.getElementById('latitude-gps-input')
 const inputLongitudeGps = document.getElementById('longitude-gps-input')
 // buttons
-const btnGetLocaleInfo = document.getElementById('get-locale-info-button')
+const btnGetLocationInfo = document.getElementById('get-location-info-button')
 
 inputLatitudeGps.addEventListener('input', () => {
   if (!isInputAValidNumber(inputLatitudeGps)) {
@@ -20,7 +20,7 @@ inputLongitudeGps.addEventListener('input', () => {
   }
 })
 
-btnGetLocaleInfo.addEventListener('click', () => {
+btnGetLocationInfo.addEventListener('click', () => {
   if (isInputAValidNumber(inputLatitudeGps) && isInputAValidNumber(inputLongitudeGps)) {
     window.location.href = `/gps/${inputLatitudeGps.value},${inputLongitudeGps.value}`
   }

--- a/src/views/index.hbs
+++ b/src/views/index.hbs
@@ -16,7 +16,7 @@
    </div>
 </div>
 
-{{> myLocalButton}}
+{{> myLocationButton}}
 
 {{> resultMap}}
 
@@ -25,7 +25,7 @@
    {{> municipalityQuery}}
    {{> parishQuery}}
    {{> cpQuery}}
-   {{> localeQuery}}
+   {{> locationQuery}}
 </div>
 
 {{> footer}}

--- a/src/views/partials/locationQuery.hbs
+++ b/src/views/partials/locationQuery.hbs
@@ -13,6 +13,6 @@
       </div>
       <input type="text" id="longitude-gps-input" class="form-control" placeholder="-9.102984" aria-label="Longitude" aria-describedby="longitude-gps-info">
     </div>
-    <button type="button" id="get-locale-info-button" class="btn btn-info">Detalhes sobre local</button>
+    <button type="button" id="get-location-info-button" class="btn btn-info">Detalhes sobre local</button>
   </div>
 </div>

--- a/src/views/partials/myLocationButton.hbs
+++ b/src/views/partials/myLocationButton.hbs
@@ -1,4 +1,4 @@
-<div id="mylocalbutton">
+<div id="mylocationbutton">
   <a href="/meulocal">
     <span>Onde estou?</span>
     <img alt="my location logo" src="/img/location.png">


### PR DESCRIPTION
The term «locale» in English is not equivalent to the Portuguese «local».
Instead, it typically refers to a language+region combination, used in software localization
to specify data like date representations, currency formatting, digit grouping characters, etc.
See https://en.wikipedia.org/wiki/Locale_(computer_software).
This can be seen in the uses of JavaScript `localeCompare()` in this codebase.
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare.

Note that there _is_ a geographic meaning of locale: https://en.wikipedia.org/wiki/Locale_(geographic)
but it is less common than the localization meaning, and introduces unnecessary ambiguity.
