### PR TITLE
Fix a CSS selector, and general CSS cleanup

### DIFF
--- a/src/public/src/css/main.css
+++ b/src/public/src/css/main.css
@@ -173,12 +173,12 @@ textarea:focus {
 	padding-bottom: 15px;
 }
 
-#mylocalbutton {
+#mylocationbutton {
 	text-align: center;
 	padding: 0 10% 15px 10%;
 }
 
-#mylocalbutton a {
+#mylocationbutton a {
 	word-break: break-word;
 	border: #b8b7b7 1px solid;
 	border-radius: 5px;
@@ -189,7 +189,7 @@ textarea:focus {
 	font-size: larger;
 }
 
-#mylocalbutton img {
+#mylocationbutton img {
 	max-height: 110px;
 }
 
@@ -249,7 +249,7 @@ textarea:focus {
 /* ========================== */
 
 @media (min-width: 500px) {
-  #mylocalbutton {
+  #mylocationbutton {
 		display: none;
 	}
 }

--- a/src/public/src/css/main.css
+++ b/src/public/src/css/main.css
@@ -17,7 +17,7 @@
 body,
 html {
 	height: 100%;
-	font-family: sans-serif
+	font-family: sans-serif;
 }
 
 body {
@@ -29,11 +29,11 @@ a {
 	transition: all .4s;
 	-webkit-transition: all .4s;
 	-o-transition: all .4s;
-	-moz-transition: all .4s
+	-moz-transition: all .4s;
 }
 
 a:focus {
-	outline: none !important
+	outline: none !important;
 }
 
 #project_title a, 
@@ -51,26 +51,26 @@ h3,
 h4,
 h5,
 h6 {
-	margin: 0
+	margin: 0;
 }
 
 p {
-	margin: 0
+	margin: 0;
 }
 
 ul,
 li {
 	margin: 0;
-	list-style-type: none
+	list-style-type: none;
 }
 
 textarea {
 	display: block;
-	outline: none
+	outline: none;
 }
 
 textarea:focus {
-	border-color: transparent !important
+	border-color: transparent !important;
 }
 
 .limiter {
@@ -281,6 +281,6 @@ textarea:focus {
 /* Mainly for PWA */
 @media all and (display-mode: standalone) {
   #header_wrap {
-    display: none
+    display: none;
   }
 }

--- a/src/public/src/css/main.css
+++ b/src/public/src/css/main.css
@@ -39,7 +39,7 @@ a:focus {
 #project_title a,
 #project_title a:hover,
 #project_title a:focus,
-#project_title a:active
+#project_title a:active,
 a, a:hover, a:focus, a:active {
 	text-decoration: none;
 	color: inherit;

--- a/src/public/src/css/main.css
+++ b/src/public/src/css/main.css
@@ -36,9 +36,9 @@ a:focus {
 	outline: none !important;
 }
 
-#project_title a, 
-#project_title a:hover, 
-#project_title a:focus, 
+#project_title a,
+#project_title a:hover,
+#project_title a:focus,
 #project_title a:active
 a, a:hover, a:focus, a:active {
 	text-decoration: none;
@@ -88,7 +88,7 @@ textarea:focus {
 }
 
 .table-info2, .table-info2>td, .table-info2>th {
-	background-color: #e8f8fb;	
+	background-color: #e8f8fb;
 }
 
 .container-table100 {
@@ -195,33 +195,33 @@ textarea:focus {
 
 /* main index page grid cards and bootstrap tweaks */
 .cards .card .btn-group-vertical button {
-  margin-top: 5px !important;
-  border-radius: 4px !important;
+	margin-top: 5px !important;
+	border-radius: 4px !important;
 }
 
 .cards .card .input-group.mb-3 {
-  margin-top: 5px !important;
-  margin-bottom: auto !important;
-  border-radius: 4px !important;
+	margin-top: 5px !important;
+	margin-bottom: auto !important;
+	border-radius: 4px !important;
 }
 
 .cards .card {
-  background-color: transparent !important;
-  padding: 1rem;
-  overflow: auto;
-  border: none !important;
+	background-color: transparent !important;
+	padding: 1rem;
+	overflow: auto;
+	border: none !important;
 }
 
 .cards {
-  max-width: 1200px;
-  margin: 0 auto;
-  display: grid;
-  grid-gap: 1rem;
+	max-width: 1200px;
+	margin: 0 auto;
+	display: grid;
+	grid-gap: 1rem;
 }
 
 .input-group-prepend div,
 .input-group-prepend label {
-  min-width: 100px;
+	min-width: 100px;
 }
 
 #latitude-gps-info {
@@ -234,22 +234,22 @@ textarea:focus {
 
 /* Screen larger than 600px? 2 column */
 @media (min-width: 600px) {
-  .cards {
-    grid-template-columns: repeat(2, 1fr);
-  }
+	.cards {
+		grid-template-columns: repeat(2, 1fr);
+	}
 }
 
 /* Screen larger than 900px? 3 columns */
 @media (min-width: 900px) {
-  .cards {
-    grid-template-columns: repeat(3, 1fr);
-  }
+	.cards {
+		grid-template-columns: repeat(3, 1fr);
+	}
 }
 
 /* ========================== */
 
 @media (min-width: 500px) {
-  #mylocationbutton {
+	#mylocationbutton {
 		display: none;
 	}
 }
@@ -280,7 +280,7 @@ textarea:focus {
 
 /* Mainly for PWA */
 @media all and (display-mode: standalone) {
-  #header_wrap {
-    display: none;
-  }
+	#header_wrap {
+		display: none;
+	}
 }

--- a/src/public/src/js/index.js
+++ b/src/public/src/js/index.js
@@ -3,7 +3,7 @@ import './index/getDistrictInfo.js'
 import './index/getMunicipalityInfo.js'
 import './index/getParishInfo.js'
 import './index/getPostalCodesInfo.js'
-import './index/getLocaleInfo.js'
+import './index/getLocationInfo.js'
 
 import { mobileCheck, jsonFetchOptions } from './functions.js'
 import * as mapFunctions from './map/map-functions.js'

--- a/src/public/src/js/index/getLocationInfo.js
+++ b/src/public/src/js/index/getLocationInfo.js
@@ -2,7 +2,7 @@
 const inputLatitudeGps = document.getElementById('latitude-gps-input')
 const inputLongitudeGps = document.getElementById('longitude-gps-input')
 // buttons
-const btnGetLocaleInfo = document.getElementById('get-locale-info-button')
+const btnGetLocationInfo = document.getElementById('get-location-info-button')
 
 inputLatitudeGps.addEventListener('input', () => {
   if (!isInputAValidNumber(inputLatitudeGps)) {
@@ -20,7 +20,7 @@ inputLongitudeGps.addEventListener('input', () => {
   }
 })
 
-btnGetLocaleInfo.addEventListener('click', () => {
+btnGetLocationInfo.addEventListener('click', () => {
   if (isInputAValidNumber(inputLatitudeGps) && isInputAValidNumber(inputLongitudeGps)) {
     window.location.href = `/gps/${inputLatitudeGps.value},${inputLongitudeGps.value}`
   }

--- a/src/views/index.hbs
+++ b/src/views/index.hbs
@@ -16,7 +16,7 @@
    </div>
 </div>
 
-{{> myLocalButton}}
+{{> myLocationButton}}
 
 {{> resultMap}}
 
@@ -25,7 +25,7 @@
    {{> municipalityQuery}}
    {{> parishQuery}}
    {{> cpQuery}}
-   {{> localeQuery}}
+   {{> locationQuery}}
 </div>
 
 {{> footer}}

--- a/src/views/partials/locationQuery.hbs
+++ b/src/views/partials/locationQuery.hbs
@@ -13,6 +13,6 @@
       </div>
       <input type="text" id="longitude-gps-input" class="form-control" placeholder="-9.102984" aria-label="Longitude" aria-describedby="longitude-gps-info">
     </div>
-    <button type="button" id="get-locale-info-button" class="btn btn-info">Detalhes sobre local</button>
+    <button type="button" id="get-location-info-button" class="btn btn-info">Detalhes sobre local</button>
   </div>
 </div>

--- a/src/views/partials/myLocationButton.hbs
+++ b/src/views/partials/myLocationButton.hbs
@@ -1,4 +1,4 @@
-<div id="mylocalbutton">
+<div id="mylocationbutton">
   <a href="/meulocal">
     <span>Onde estou?</span>
     <img alt="my location logo" src="/img/location.png">


### PR DESCRIPTION
One of the selectors was missing a comma, resulting in an incorrect DOM query: it was looking for `#project_title a:active a` (i.e. an anchor nested inside another, which isn't even valid HTML) rather than `#project_title a:active` *and* a bare `a`.

In addition, two cleanup/normalization changes were performed in the main CSS file:
- Add missing semicolons
- Fix whitespace (consistency use tabs for indentation, and remove EOL spaces)
