### PR TITLE
Fix functionality of municipality form

### DIFF
--- a/src/views/partials/municipalityQuery.hbs
+++ b/src/views/partials/municipalityQuery.hbs
@@ -6,7 +6,7 @@
         <label class="input-group-text" for="select-municipality-info">Município</label>
       </div>
       <select class="custom-select" id="select-municipality-info">
-        <option selected>Selecione...</option>
+        <option value="0" selected>Selecione...</option>
       </select>
     </div>
     <button type="button" id="get-municipality-info-button" class="btn btn-info" disabled>Dados gerais</button>


### PR DESCRIPTION
The disabling of the buttons when no municipality is selected was not working because the first entry in the select menu did not have the value 0 as is the case with the other select menus.
