### PR TITLE
Improve behavior of the parish query form

### DIFF
--- a/src/public/src/js/index/getParishInfo.js
+++ b/src/public/src/js/index/getParishInfo.js
@@ -9,25 +9,31 @@ const btnGetParishesSections = document.getElementById('get-parish-sections-butt
 const btnGetParishesSubsections = document.getElementById('get-parish-subsections-button')
 
 selectMunicipality.addEventListener('change', () => {
-  fetch(`/municipio/${encodeURIComponent(selectMunicipality.value)}/freguesias?json=1`)
-    .then(res => res.json())
-    .then((res) => {
-      // clean select
-      const length = selectFreguesia.options.length
-      for (let i = length - 1; i >= 0; i--) {
-        selectFreguesia.options[i] = null
-      }
+  // Clean list of parishes (except the 0th item, "Select...")
+  const length = selectFreguesia.options.length
+  for (let i = length - 1; i > 0; i--) {
+    selectFreguesia.remove(i)
+  }
 
-      selectFreguesia.options.add(new Option('Selecione...', '0'))
-      res.freguesias.forEach(el => {
-        selectFreguesia.options.add(new Option(el, el))
+  if (selectMunicipality.value && selectMunicipality.value !== '0') {
+    fetch(`/municipio/${encodeURIComponent(selectMunicipality.value)}/freguesias?json=1`)
+      .then(res => res.json())
+      .then((res) => {
+        res.freguesias.forEach(el => {
+          selectFreguesia.options.add(new Option(el, el))
+        })
+
+        selectFreguesia.disabled = false
       })
-
-      selectFreguesia.disabled = false
-    })
-    .catch((err) => {
-      console.error('error fetching freguesias', err)
-    })
+      .catch((err) => {
+        console.error('error fetching freguesias', err)
+      })
+  } else {
+    selectFreguesia.disabled = true
+    btnGetParishesInfo.disabled = true
+    btnGetParishesSections.disabled = true
+    btnGetParishesSubsections.disabled = true
+  }
 })
 
 selectFreguesia.addEventListener('change', () => {

--- a/src/views/partials/parishQuery.hbs
+++ b/src/views/partials/parishQuery.hbs
@@ -14,6 +14,7 @@
         <label class="input-group-text" for="select-parish-on-parish-info">Freguesia</label>
       </div>
       <select class="custom-select" id="select-parish-on-parish-info" disabled>
+        <option value="0" selected>Selecione...</option>
       </select>
     </div>
     <button type="button" id="get-parish-info-button" class="btn btn-info" disabled>Dados gerais</button>


### PR DESCRIPTION
- Don't attempt to fetch the list of parishes of a municipality if no municipality is selected (i.e. the "Selecione..." entry is picked from the "Município" dropdown menu)
- Clear the list of parishes unconditionally whenever the municipality selection changes (even if it changes to no selection)
- Improve the code to clear the parishes list:
  - Always keep the "Selecione..." zeroth item
  - Use the HTMLSelectElement.remove() method instead of setting each option to null
- Disable the buttons and the parish selection menu if no municipality is selected
